### PR TITLE
Fix dashboard redirect path

### DIFF
--- a/actions/auth_action.php
+++ b/actions/auth_action.php
@@ -21,7 +21,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
         // Basic validation
         if (empty($email) || empty($password)) {
             $_SESSION['login_error'] = 'Email and password are required.';
-            header('Location: /login.php');
+            header('Location: ' . url_for('login.php'));
             exit();
         }
 
@@ -42,7 +42,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
                 // Check if the user account is active
                 if (!$user['is_active']) {
                     $_SESSION['login_error'] = 'Your account is deactivated. Please contact an administrator.';
-                    header('Location: /login.php');
+                    header('Location: ' . url_for('login.php'));
                     exit();
                 }
 
@@ -53,26 +53,26 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
                 $_SESSION['role_id'] = $user['role_id'];
 
                 // 5. Redirect to the dashboard
-                header('Location: /dashboard.php');
+                header('Location: ' . url_for('dashboard.php'));
                 exit();
 
             } else {
                 // Password was incorrect
                 $_SESSION['login_error'] = 'Invalid email or password.';
-                header('Location: /login.php');
+                header('Location: ' . url_for('login.php'));
                 exit();
             }
         } else {
             // No user found with that email
             $_SESSION['login_error'] = 'Invalid email or password.';
-            header('Location: /login.php');
+            header('Location: ' . url_for('login.php'));
             exit();
         }
         $stmt->close();
     }
 } else {
     // If someone tries to access this file directly, redirect them.
-    header('Location: /login.php');
+    header('Location: ' . url_for('login.php'));
     exit();
 }
 ?>

--- a/actions/document_action.php
+++ b/actions/document_action.php
@@ -16,7 +16,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
         // Security check
         if (!has_permission($conn, 'manage_documents')) {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'You do not have permission to perform this action.'];
-            header('Location: /documents.php');
+            header('Location: ' . url_for('documents.php'));
             exit();
         }
 
@@ -28,7 +28,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
 
         if (empty($name) || empty($type) || empty($content)) {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'All fields are required.'];
-            header('Location: /create_document_template.php' . ($template_id ? '?id=' . $template_id : ''));
+            header('Location: ' . url_for('create_document_template.php') . ($template_id ? '?id=' . $template_id : ''));
             exit();
         }
 
@@ -50,10 +50,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
         // 3. Execute the query
         if ($stmt->execute()) {
             $_SESSION['flash_message'] = ['type' => 'success', 'message' => $message];
-            header('Location: /documents.php');
+            header('Location: ' . url_for('documents.php'));
         } else {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'Failed to save template.'];
-            header('Location: /create_document_template.php' . ($template_id ? '?id=' . $template_id : ''));
+            header('Location: ' . url_for('create_document_template.php') . ($template_id ? '?id=' . $template_id : ''));
         }
         $stmt->close();
         exit();
@@ -143,7 +143,7 @@ HTML;
     }
 
 } else {
-    header('Location: /dashboard.php');
+    header('Location: ' . url_for('dashboard.php'));
     exit();
 }
 ?>

--- a/actions/employee_action.php
+++ b/actions/employee_action.php
@@ -16,7 +16,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
         // Security check
         if (!has_permission($conn, 'manage_employees')) {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'You do not have permission to perform this action.'];
-            header('Location: /employees.php');
+            header('Location: ' . url_for('employees.php'));
             exit();
         }
 
@@ -33,12 +33,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
         // --- 2. Server-side Validation ---
         if (empty($first_name) || empty($last_name) || empty($email) || empty($password) || empty($designation) || empty($department) || empty($date_of_joining)) {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'All fields are required.'];
-            header('Location: /add_employee.php');
+            header('Location: ' . url_for('add_employee.php'));
             exit();
         }
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'Invalid email format.'];
-            header('Location: /add_employee.php');
+            header('Location: ' . url_for('add_employee.php'));
             exit();
         }
 
@@ -74,13 +74,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
             // Commit the transaction
             $conn->commit();
             $_SESSION['flash_message'] = ['type' => 'success', 'message' => 'Employee added successfully!'];
-            header('Location: /employees.php');
+            header('Location: ' . url_for('employees.php'));
             exit();
 
         } catch (Exception $e) {
             $conn->rollback();
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'Failed to add employee: ' . $e->getMessage()];
-            header('Location: /add_employee.php');
+            header('Location: ' . url_for('add_employee.php'));
             exit();
         }
     }
@@ -90,7 +90,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
         // Security check
         if (!has_permission($conn, 'manage_employees')) {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'You do not have permission to perform this action.'];
-            header('Location: /employees.php');
+            header('Location: ' . url_for('employees.php'));
             exit();
         }
 
@@ -112,13 +112,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'Failed to update employee status.'];
         }
         $stmt->close();
-        header('Location: /employees.php');
+        header('Location: ' . url_for('employees.php'));
         exit();
     }
 
 } else {
     // If accessed directly or without a POST method
-    header('Location: /dashboard.php');
+    header('Location: ' . url_for('dashboard.php'));
     exit();
 }
 ?>

--- a/actions/invoice_action.php
+++ b/actions/invoice_action.php
@@ -16,7 +16,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
         // Security check
         if (!has_permission($conn, 'manage_invoices')) {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'You do not have permission to create invoices.'];
-            header('Location: /invoices.php');
+            header('Location: ' . url_for('invoices.php'));
             exit();
         }
 
@@ -50,7 +50,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
 
         if (empty($invoice_items)) {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'Cannot create an empty invoice. Please add at least one item.'];
-            header('Location: /create_invoice.php');
+            header('Location: ' . url_for('create_invoice.php'));
             exit();
         }
 
@@ -81,7 +81,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
             // If all queries were successful, commit the transaction
             $conn->commit();
             $_SESSION['flash_message'] = ['type' => 'success', 'message' => 'Invoice created successfully!'];
-            header('Location: /invoices.php');
+            header('Location: ' . url_for('invoices.php'));
             exit();
 
         } catch (mysqli_sql_exception $exception) {
@@ -89,12 +89,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
             $conn->rollback();
             error_log("Invoice creation failed: " . $exception->getMessage());
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'Failed to create invoice. Please try again.'];
-            header('Location: /create_invoice.php');
+            header('Location: ' . url_for('create_invoice.php'));
             exit();
         }
     }
 } else {
-    header('Location: /dashboard.php');
+    header('Location: ' . url_for('dashboard.php'));
     exit();
 }
 ?>

--- a/actions/leave_action.php
+++ b/actions/leave_action.php
@@ -21,7 +21,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
 
         if (empty($start_date) || empty($end_date) || empty($reason)) {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'All fields are required.'];
-            header('Location: /apply_leave.php');
+            header('Location: ' . url_for('apply_leave.php'));
             exit();
         }
 
@@ -32,7 +32,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
         $result_emp = $stmt_emp->get_result();
         if ($result_emp->num_rows === 0) {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'Could not find employee record for your user account.'];
-            header('Location: /apply_leave.php');
+            header('Location: ' . url_for('apply_leave.php'));
             exit();
         }
         $employee = $result_emp->fetch_assoc();
@@ -50,7 +50,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'Failed to submit leave request. Please try again.'];
         }
         $stmt->close();
-        header('Location: /leaves.php');
+        header('Location: ' . url_for('leaves.php'));
         exit();
     }
 
@@ -59,7 +59,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
         // Security check
         if (!has_permission($conn, 'manage_leaves')) {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'You do not have permission to perform this action.'];
-            header('Location: /leaves.php');
+            header('Location: ' . url_for('leaves.php'));
             exit();
         }
 
@@ -68,7 +68,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
 
         if (empty($leave_id) || !in_array($new_status, ['Approved', 'Rejected'])) {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'Invalid request.'];
-            header('Location: /leaves.php');
+            header('Location: ' . url_for('leaves.php'));
             exit();
         }
 
@@ -82,11 +82,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'Failed to update leave status.'];
         }
         $stmt->close();
-        header('Location: /leaves.php');
+        header('Location: ' . url_for('leaves.php'));
         exit();
     }
 } else {
-    header('Location: /dashboard.php');
+    header('Location: ' . url_for('dashboard.php'));
     exit();
 }
 ?>

--- a/actions/user_action.php
+++ b/actions/user_action.php
@@ -19,7 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
 
         if (empty($name)) {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'Name cannot be empty.'];
-            header('Location: /profile.php');
+            header('Location: ' . url_for('profile.php'));
             exit();
         }
 
@@ -36,7 +36,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'Failed to update profile.'];
         }
         $stmt->close();
-        header('Location: /profile.php');
+        header('Location: ' . url_for('profile.php'));
         exit();
     }
 
@@ -50,12 +50,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
         // 1. Validation
         if (empty($current_password) || empty($new_password) || empty($confirm_password)) {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'All password fields are required.', 'form' => 'password'];
-            header('Location: /profile.php');
+            header('Location: ' . url_for('profile.php'));
             exit();
         }
         if ($new_password !== $confirm_password) {
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'New password and confirmation do not match.', 'form' => 'password'];
-            header('Location: /profile.php');
+            header('Location: ' . url_for('profile.php'));
             exit();
         }
 
@@ -82,11 +82,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
             // Current password was incorrect
             $_SESSION['flash_message'] = ['type' => 'error', 'message' => 'Incorrect current password.', 'form' => 'password'];
         }
-        header('Location: /profile.php');
+        header('Location: ' . url_for('profile.php'));
         exit();
     }
 } else {
-    header('Location: /dashboard.php');
+    header('Location: ' . url_for('dashboard.php'));
     exit();
 }
 ?>

--- a/generate_document.php
+++ b/generate_document.php
@@ -18,7 +18,7 @@ if (!has_permission($conn, 'manage_documents')) {
 
 // Get template ID from URL
 if (!isset($_GET['template_id'])) {
-    header('Location: /documents.php');
+    header('Location: ' . url_for('documents.php'));
     exit();
 }
 $template_id = $_GET['template_id'];
@@ -65,7 +65,7 @@ $employees_result = $conn->query("SELECT e.id, e.first_name, e.last_name FROM em
             <!-- Form Actions -->
             <div class="pt-5 border-t border-gray-200">
                 <div class="flex justify-end">
-                    <a href="documents.php" class="bg-white py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50">Cancel</a>
+                    <a href="<?php echo url_for('documents.php'); ?>" class="bg-white py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50">Cancel</a>
                     <button type="submit" class="ml-3 inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-700">
                         Generate & Preview
                     </button>

--- a/includes/header.php
+++ b/includes/header.php
@@ -50,7 +50,7 @@ require_login(); // This function is from db.php
                 </div>
                 <div class="flex items-center space-x-4">
                     <span class="text-sm font-medium text-gray-600">Welcome, <?php echo e($_SESSION['user_name']); ?></span>
-                    <a href="/logout.php" class="text-sm font-medium text-indigo-600 hover:text-indigo-800">Logout</a>
+                    <a href="<?php echo url_for('logout.php'); ?>" class="text-sm font-medium text-indigo-600 hover:text-indigo-800">Logout</a>
                 </div>
             </header>
             <main class="flex-1 overflow-x-hidden overflow-y-auto bg-gray-100 p-6">

--- a/includes/sidebar.php
+++ b/includes/sidebar.php
@@ -13,40 +13,40 @@ $current_page = basename($_SERVER['SCRIPT_NAME']);
         <h2 class="text-2xl font-bold">Company Inc.</h2>
     </div>
     <nav class="flex-1 px-2 py-4 space-y-2">
-        <a href="/dashboard.php" class="sidebar-link flex items-center px-4 py-2.5 rounded-md hover:bg-gray-700 <?php echo ($current_page == 'dashboard.php') ? 'active' : ''; ?>">
+        <a href="<?php echo url_for('dashboard.php'); ?>" class="sidebar-link flex items-center px-4 py-2.5 rounded-md hover:bg-gray-700 <?php echo ($current_page == 'dashboard.php') ? 'active' : ''; ?>">
             Dashboard
         </a>
 
-        <a href="/profile.php" class="sidebar-link flex items-center px-4 py-2.5 rounded-md hover:bg-gray-700 <?php echo ($current_page == 'profile.php') ? 'active' : ''; ?>">
+        <a href="<?php echo url_for('profile.php'); ?>" class="sidebar-link flex items-center px-4 py-2.5 rounded-md hover:bg-gray-700 <?php echo ($current_page == 'profile.php') ? 'active' : ''; ?>">
             My Profile
         </a>
 
         <?php if (has_permission($conn, 'manage_employees')): ?>
-            <a href="/employees.php" class="sidebar-link flex items-center px-4 py-2.5 rounded-md hover:bg-gray-700 <?php echo in_array($current_page, ['employees.php', 'add_employee.php']) ? 'active' : ''; ?>">
+            <a href="<?php echo url_for('employees.php'); ?>" class="sidebar-link flex items-center px-4 py-2.5 rounded-md hover:bg-gray-700 <?php echo in_array($current_page, ['employees.php', 'add_employee.php']) ? 'active' : ''; ?>">
                 Employee Management
             </a>
         <?php endif; ?>
 
         <?php if (has_permission($conn, 'manage_leaves') || $_SESSION['role_id'] == 4): // Show to managers or employees ?>
-            <a href="/leaves.php" class="sidebar-link flex items-center px-4 py-2.5 rounded-md hover:bg-gray-700 <?php echo in_array($current_page, ['leaves.php', 'apply_leave.php']) ? 'active' : ''; ?>">
+            <a href="<?php echo url_for('leaves.php'); ?>" class="sidebar-link flex items-center px-4 py-2.5 rounded-md hover:bg-gray-700 <?php echo in_array($current_page, ['leaves.php', 'apply_leave.php']) ? 'active' : ''; ?>">
                 Leave Management
             </a>
         <?php endif; ?>
 
         <?php if (has_permission($conn, 'manage_invoices')): ?>
-            <a href="/invoices.php" class="sidebar-link flex items-center px-4 py-2.5 rounded-md hover:bg-gray-700 <?php echo in_array($current_page, ['invoices.php', 'create_invoice.php']) ? 'active' : ''; ?>">
+            <a href="<?php echo url_for('invoices.php'); ?>" class="sidebar-link flex items-center px-4 py-2.5 rounded-md hover:bg-gray-700 <?php echo in_array($current_page, ['invoices.php', 'create_invoice.php']) ? 'active' : ''; ?>">
                 Finance & Invoices
             </a>
         <?php endif; ?>
 
         <?php if (has_permission($conn, 'manage_documents')): ?>
-            <a href="/documents.php" class="sidebar-link flex items-center px-4 py-2.5 rounded-md hover:bg-gray-700 <?php echo in_array($current_page, ['documents.php', 'create_document_template.php', 'generate_document.php']) ? 'active' : ''; ?>">
+            <a href="<?php echo url_for('documents.php'); ?>" class="sidebar-link flex items-center px-4 py-2.5 rounded-md hover:bg-gray-700 <?php echo in_array($current_page, ['documents.php', 'create_document_template.php', 'generate_document.php']) ? 'active' : ''; ?>">
                 Documents
             </a>
         <?php endif; ?>
 
         <?php if (has_permission($conn, 'view_reports')): ?>
-            <a href="/reports.php" class="sidebar-link flex items-center px-4 py-2.5 rounded-md hover:bg-gray-700 <?php echo ($current_page == 'reports.php') ? 'active' : ''; ?>">
+            <a href="<?php echo url_for('reports.php'); ?>" class="sidebar-link flex items-center px-4 py-2.5 rounded-md hover:bg-gray-700 <?php echo ($current_page == 'reports.php') ? 'active' : ''; ?>">
                 Reports
             </a>
         <?php endif; ?>

--- a/login.php
+++ b/login.php
@@ -11,7 +11,7 @@ require_once 'config/db.php';
 
 // If a user is already logged in, redirect them to the dashboard.
 if (isset($_SESSION['user_id'])) {
-    header('Location: dashboard.php');
+    header('Location: ' . url_for('dashboard.php'));
     exit();
 }
 

--- a/logout.php
+++ b/logout.php
@@ -17,7 +17,8 @@ $_SESSION = array();
 // Destroy the session
 session_destroy();
 
+require_once __DIR__ . '/config/db.php';
 // Redirect to the login page
-header("Location: /login.php");
+header("Location: " . url_for('login.php'));
 exit();
 ?>


### PR DESCRIPTION
Make all application redirects and links base-path aware to support deployment in subdirectories.

The application was using hardcoded absolute paths for redirects and links (e.g., `/dashboard.php`). When deployed in a subfolder like `/core/`, these absolute paths caused incorrect redirects to the root (e.g., `127.0.0.1/dashboard.php`) instead of the intended subfolder path (`127.0.0.1/core/dashboard.php`). This PR introduces a `url_for()` helper to dynamically determine the application's base path and ensures all internal links and redirects correctly resolve relative to the application's actual deployment location.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e22edd7-8bfb-4009-82eb-84557a58a7ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8e22edd7-8bfb-4009-82eb-84557a58a7ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

